### PR TITLE
Feature: Player-Specific Last Move Time & Reduced Cooldown

### DIFF
--- a/fastapi/app/crud.py
+++ b/fastapi/app/crud.py
@@ -187,13 +187,13 @@ async def get_next_player_to_process(db: AsyncSession):
     
     Selection Criteria:
     1. Depth <= 1 (Main user or immediate opponents).
-    2. Has NOT been fetched in the last 24 hours.
+    2. Has NOT been fetched in the last 1 hour.
     
     Concurrency Safety:
     Uses `FOR UPDATE SKIP LOCKED` to ensure that if multiple orchestrators run,
     they don't pick the same player.
     """
-    cutoff = datetime.now(timezone.utc) - timedelta(hours=24)
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=1)
     
     # Select with SKIP LOCKED to prevent race conditions
     stmt = select(models.Player).where(

--- a/fastapi/app/main.py
+++ b/fastapi/app/main.py
@@ -90,6 +90,14 @@ async def fetch_last_move_time(db: AsyncSession = Depends(get_db)):
     last_move_time = await crud.get_last_move_time(db)
     return last_move_time
 
+@app.get("/games/get_last_move_played_time/{player_id}", response_model=schemas.LastMoveTimeResponse)
+async def fetch_last_move_time_for_player(player_id: str, db: AsyncSession = Depends(get_db)):
+    """
+    Returns the timestamp of the most recent move for a specific player.
+    """
+    last_move_time = await crud.get_last_move_time_for_player(db, player_id)
+    return {"last_move_time": last_move_time}
+
 @app.post("/games/{game_id}/moves/", response_model=list[schemas.GameMove], status_code=status.HTTP_201_CREATED)
 async def add_moves(
     game_id: str,


### PR DESCRIPTION
## Description
This PR introduces a new endpoint to fetch the last move time for a specific player, enabling robust idempotency for game fetching. It also integrates this endpoint into the Celery tasks to ensure that both the main user and opponents resume fetching from the correct point. Additionally, the fetch cooldown for players has been reduced to improve data freshness.

## Key Changes
- **New Endpoint**: Added `GET /games/get_last_move_played_time/{player_id}` to retrieve the timestamp of the last stored move for a specific user.
- **Idempotency**: Updated fetch_player_games to automatically query this new endpoint if no `since` cursor is provided. This ensures that manual task triggers or retries resume correctly without duplicating data.
- **Orchestrator Update**: The orchestrator now specifically requests the last move time for the main user, preventing potential conflicts with opponent data.
- **Cooldown Reduction**: Reduced the re-fetch cooldown for players from **24 hours** to **1 hour**, allowing for more frequent updates.